### PR TITLE
Improve SRT logging and add usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ When building with CMake leave the `-DSRT` option enabled (default) and
 ensure that `pkg-config` can locate the `srt` library. If the library is
 missing the build system will automatically disable SRT support.
 
+### SRT streaming
+
+By default audio sent via the `srt` output is raw 32‑bit float PCM at
+8&nbsp;kHz. A typical client is `ffplay`:
+
+```
+ffplay -ac 1 -ar 8000 -analyzeduration 0 -probesize 32 -f f32le srt://<host>:<port>
+```
+
+Setting `format = "mp3"` on the output encodes the audio using libmp3lame
+before sending it. In this mode standard players (including VLC) can open
+`srt://<host>:<port>` directly without specifying any parameters.
+
 ## Credits and thanks
 
 I hereby express my gratitude to everybody who helped with the development and testing

--- a/config/srt_example.conf
+++ b/config/srt_example.conf
@@ -21,6 +21,7 @@ devices:
             type = "srt";
             listen_address = "0.0.0.0";
             listen_port = 8890;
+            format = "mp3";
           }
         );
       }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -266,6 +266,26 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 cerr << "missing listen_port\n";
                 error();
             }
+
+            if (outs[o].exists("format")) {
+                const char* fmt = outs[o]["format"];
+                if (!strcmp(fmt, "mp3")) {
+                    sdata->mp3 = true;
+                    channel->outputs[oo].has_mp3_output = true;
+                } else if (!strcmp(fmt, "raw")) {
+                    sdata->mp3 = false;
+                } else {
+                    if (parsing_mixers) {
+                        cerr << "Configuration error: mixers.[" << i << "] outputs.[" << o << "]: ";
+                    } else {
+                        cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o << "]: ";
+                    }
+                    cerr << "invalid SRT format, must be 'raw' or 'mp3'\n";
+                    error();
+                }
+            } else {
+                sdata->mp3 = false;
+            }
 #ifdef WITH_PULSEAUDIO
         } else if (!strncmp(outs[o]["type"], "pulse", 5)) {
             channel->outputs[oo].data = XCALLOC(1, sizeof(struct pulse_data));

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -170,6 +170,8 @@ struct srt_stream_data {
 
     int payload_size;
 
+    bool mp3;
+
     bool continuous;
     const char* listen_address;
     const char* listen_port;
@@ -417,6 +419,7 @@ void udp_stream_shutdown(udp_stream_data* sdata);
 bool srt_stream_init(srt_stream_data* sdata, mix_modes mode, size_t len);
 void srt_stream_write(srt_stream_data* sdata, const float* data, size_t len);
 void srt_stream_write(srt_stream_data* sdata, const float* data_left, const float* data_right, size_t len);
+void srt_stream_send_bytes(srt_stream_data* sdata, const unsigned char* data, size_t len);
 void srt_stream_shutdown(srt_stream_data* sdata);
 
 #ifdef WITH_PULSEAUDIO


### PR DESCRIPTION
## Summary
- reduce SRT log noise by setting log level to errors only
- document how to connect to a raw SRT audio stream
- add mp3 option for SRT streaming

## Testing
- `cmake .. -DSRT=ON`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68606518c3c08325b6e15f1157340f63