### PR TITLE
Add WAV support for SRT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ By default audio sent via the `srt` output is raw 32‑bit float PCM at
 ffplay -ac 1 -ar 8000 -analyzeduration 0 -probesize 32 -f f32le srt://<host>:<port>
 ```
 
-Setting `format = "mp3"` on the output encodes the audio using libmp3lame
-before sending it. In this mode standard players (including VLC) can open
-`srt://<host>:<port>` directly without specifying any parameters.
+Setting `format = "mp3"` encodes the audio using libmp3lame.  When
+`format = "wav"` a simple WAV header is sent before the audio stream
+allowing players such as VLC to connect without any additional
+parameters.  If omitted or set to `pcm` the stream is raw 32‑bit float
+PCM and clients must specify the format as shown above.
 
 ## Credits and thanks
 

--- a/config/srt_example.conf
+++ b/config/srt_example.conf
@@ -21,6 +21,7 @@ devices:
             type = "srt";
             listen_address = "0.0.0.0";
             listen_port = 8890;
+            # format can be "pcm" (default), "mp3" or "wav"
             format = "mp3";
           }
         );

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -270,21 +270,23 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             if (outs[o].exists("format")) {
                 const char* fmt = outs[o]["format"];
                 if (!strcmp(fmt, "mp3")) {
-                    sdata->mp3 = true;
+                    sdata->format = SRT_STREAM_MP3;
                     channel->outputs[oo].has_mp3_output = true;
-                } else if (!strcmp(fmt, "raw")) {
-                    sdata->mp3 = false;
+                } else if (!strcmp(fmt, "raw") || !strcmp(fmt, "pcm")) {
+                    sdata->format = SRT_STREAM_PCM;
+                } else if (!strcmp(fmt, "wav")) {
+                    sdata->format = SRT_STREAM_WAV;
                 } else {
                     if (parsing_mixers) {
                         cerr << "Configuration error: mixers.[" << i << "] outputs.[" << o << "]: ";
                     } else {
                         cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o << "]: ";
                     }
-                    cerr << "invalid SRT format, must be 'raw' or 'mp3'\n";
+                    cerr << "invalid SRT format, must be 'pcm', 'mp3' or 'wav'\n";
                     error();
                 }
             } else {
-                sdata->mp3 = false;
+                sdata->format = SRT_STREAM_PCM;
             }
 #ifdef WITH_PULSEAUDIO
         } else if (!strncmp(outs[o]["type"], "pulse", 5)) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -157,6 +157,8 @@ lame_t airlame_init(mix_modes mixmode, int highpass, int lowpass) {
     lame_set_quality(lame, 7);
     lame_set_lowpassfreq(lame, lowpass);
     lame_set_highpassfreq(lame, highpass);
+    /* Disable the bit reservoir to reduce encoder latency */
+    lame_set_disable_reservoir(lame, 1);
     lame_set_out_samplerate(lame, MP3_RATE);
     if (mixmode == MM_STEREO) {
         lame_set_num_channels(lame, 2);
@@ -574,7 +576,7 @@ void process_outputs(channel_t* channel, int cur_scan_freq) {
             if (sdata->continuous == false && channel->axcindicate == NO_SIGNAL)
                 continue;
 
-            if (sdata->mp3) {
+            if (sdata->format == SRT_STREAM_MP3) {
                 const auto& lame = channel->outputs[k].lame;
                 const auto& lamebuf = channel->outputs[k].lamebuf;
                 int mp3_bytes = lame_encode_buffer_ieee_float(

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -164,20 +164,35 @@ struct udp_stream_data {
     socklen_t dest_sockaddr_len;
 };
 
+enum srt_stream_format {
+    SRT_STREAM_PCM,
+    SRT_STREAM_MP3,
+    SRT_STREAM_WAV
+};
+
+struct srt_client {
+    SRTSOCKET sock;
+    bool header_sent;
+};
+
 struct srt_stream_data {
     float* stereo_buffer;
     size_t stereo_buffer_len;
 
+    int16_t* pcm_buffer;
+    size_t pcm_buffer_len;
+
     int payload_size;
 
-    bool mp3;
+    srt_stream_format format;
+    mix_modes mode;
 
     bool continuous;
     const char* listen_address;
     const char* listen_port;
 
     SRTSOCKET listen_socket;
-    std::vector<SRTSOCKET> clients;
+    std::vector<srt_client> clients;
 };
 
 #ifdef WITH_PULSEAUDIO

--- a/src/srt_stream.cpp
+++ b/src/srt_stream.cpp
@@ -3,6 +3,9 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <vector>
+#include <stdint.h>
+#include <stdlib.h>
+#include <srt/logging_api.h>
 
 #include "rtl_airband.h"
 
@@ -10,6 +13,9 @@
 
 static bool srt_initialized = false;
 static void srt_stream_accept(srt_stream_data* sdata);
+static void srt_stream_send_header(srt_stream_data* sdata, srt_client& client);
+
+static void srt_log_dummy(void*, int, const char*, int, const char*, const char*) {}
 
 static void srt_try_startup() {
     if (!srt_initialized) {
@@ -17,8 +23,9 @@ static void srt_try_startup() {
             log(LOG_ERR, "srt_stream: srt_startup failed: %s\n", srt_getlasterror_str());
         } else {
             srt_initialized = true;
-            /* Reduce noise from libsrt by only logging errors */
-            srt_setloglevel(LOG_ERR);
+            /* Reduce noise from libsrt by disabling log output */
+            srt_setloglevel(LOG_CRIT);
+            srt_setloghandler(NULL, srt_log_dummy);
         }
     }
 }
@@ -29,16 +36,21 @@ static void srt_stream_send(srt_stream_data* sdata, const char* data, size_t len
 
     srt_stream_accept(sdata);
     for (auto it = sdata->clients.begin(); it != sdata->clients.end();) {
+        if (sdata->format == SRT_STREAM_WAV && !it->header_sent) {
+            srt_stream_send_header(sdata, *it);
+            it->header_sent = true;
+        }
+
         const char* ptr = data;
         size_t remaining = len;
         while (remaining > 0) {
             int chunk = remaining > (size_t)sdata->payload_size ? sdata->payload_size : remaining;
-            int ret = srt_send(*it, ptr, chunk);
+            int ret = srt_send(it->sock, ptr, chunk);
             if (ret == SRT_ERROR) {
                 int serr;
                 srt_getlasterror(&serr);
                 if (serr != SRT_EASYNCSND) {
-                    srt_close(*it);
+                    srt_close(it->sock);
                     it = sdata->clients.erase(it);
                     goto next_client;
                 }
@@ -59,12 +71,22 @@ bool srt_stream_init(srt_stream_data* sdata, mix_modes mode, size_t len) {
         return false;
     }
 
-    if (!sdata->mp3 && mode == MM_STEREO) {
+    sdata->mode = mode;
+
+    if (sdata->format != SRT_STREAM_MP3 && mode == MM_STEREO) {
         sdata->stereo_buffer_len = (len / sizeof(float)) * 2;
         sdata->stereo_buffer = (float*)XCALLOC(sdata->stereo_buffer_len, sizeof(float));
     } else {
         sdata->stereo_buffer_len = 0;
         sdata->stereo_buffer = NULL;
+    }
+
+    if (sdata->format == SRT_STREAM_WAV) {
+        sdata->pcm_buffer_len = (len / sizeof(float)) * (mode == MM_STEREO ? 2 : 1);
+        sdata->pcm_buffer = (int16_t*)XCALLOC(sdata->pcm_buffer_len, sizeof(int16_t));
+    } else {
+        sdata->pcm_buffer_len = 0;
+        sdata->pcm_buffer = NULL;
     }
 
     sdata->listen_socket = srt_create_socket();
@@ -82,6 +104,12 @@ bool srt_stream_init(srt_stream_data* sdata, mix_modes mode, size_t len) {
     int blocking = 0;
     srt_setsockopt(sdata->listen_socket, 0, SRTO_SNDSYN, &blocking, sizeof(blocking));
     srt_setsockopt(sdata->listen_socket, 0, SRTO_RCVSYN, &blocking, sizeof(blocking));
+
+    /* Disable timestamp-based packet delivery for minimal latency */
+    int tsbpd = 0;
+    srt_setsockopt(sdata->listen_socket, 0, SRTO_TSBPDMODE, &tsbpd, sizeof(tsbpd));
+    int zero = 0;
+    srt_setsockopt(sdata->listen_socket, 0, SRTO_LATENCY, &zero, sizeof(zero));
 
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
@@ -106,6 +134,39 @@ bool srt_stream_init(srt_stream_data* sdata, mix_modes mode, size_t len) {
     return true;
 }
 
+static void srt_stream_send_header(srt_stream_data* sdata, srt_client& client) {
+    if (sdata->format != SRT_STREAM_WAV)
+        return;
+
+    const int channels = (sdata->mode == MM_STEREO) ? 2 : 1;
+    const int sample_rate = WAVE_RATE;
+    const int bits_per_sample = 16;
+    uint32_t byte_rate = sample_rate * channels * bits_per_sample / 8;
+    uint16_t block_align = channels * bits_per_sample / 8;
+
+    char header[44];
+    memcpy(header, "RIFF", 4);
+    uint32_t sz = 0xffffffffu; /* unknown length */
+    memcpy(header + 4, &sz, 4);
+    memcpy(header + 8, "WAVEfmt ", 8);
+    uint32_t fmt_size = 16;
+    memcpy(header + 16, &fmt_size, 4);
+    uint16_t audio_format = 1; /* PCM */
+    memcpy(header + 20, &audio_format, 2);
+    uint16_t ch = channels;
+    memcpy(header + 22, &ch, 2);
+    uint32_t sr = sample_rate;
+    memcpy(header + 24, &sr, 4);
+    memcpy(header + 28, &byte_rate, 4);
+    memcpy(header + 32, &block_align, 2);
+    uint16_t bps = bits_per_sample;
+    memcpy(header + 34, &bps, 2);
+    memcpy(header + 36, "data", 4);
+    memcpy(header + 40, &sz, 4);
+
+    srt_send(client.sock, header, sizeof(header));
+}
+
 static void srt_stream_accept(srt_stream_data* sdata) {
     while (true) {
         struct sockaddr_storage rem;
@@ -121,12 +182,32 @@ static void srt_stream_accept(srt_stream_data* sdata) {
         int blocking = 0;
         srt_setsockopt(s, 0, SRTO_SNDSYN, &blocking, sizeof(blocking));
         srt_setsockopt(s, 0, SRTO_RCVSYN, &blocking, sizeof(blocking));
-        sdata->clients.push_back(s);
+        int tsbpd = 0;
+        srt_setsockopt(s, 0, SRTO_TSBPDMODE, &tsbpd, sizeof(tsbpd));
+        int zero = 0;
+        srt_setsockopt(s, 0, SRTO_LATENCY, &zero, sizeof(zero));
+        srt_client c{ s, false };
+        sdata->clients.push_back(c);
     }
 }
 
 void srt_stream_write(srt_stream_data* sdata, const float* data, size_t len) {
-    srt_stream_send(sdata, (const char*)data, len);
+    if (sdata->format == SRT_STREAM_WAV) {
+        size_t sample_count = len / sizeof(float);
+        if (sample_count > sdata->pcm_buffer_len)
+            return;
+        for (size_t i = 0; i < sample_count; ++i) {
+            float v = data[i];
+            if (v > 1.0f)
+                v = 1.0f;
+            else if (v < -1.0f)
+                v = -1.0f;
+            sdata->pcm_buffer[i] = (int16_t)(v * 32767.0f);
+        }
+        srt_stream_send(sdata, (const char*)sdata->pcm_buffer, sample_count * sizeof(int16_t));
+    } else {
+        srt_stream_send(sdata, (const char*)data, len);
+    }
 }
 
 void srt_stream_send_bytes(srt_stream_data* sdata, const unsigned char* data, size_t len) {
@@ -143,14 +224,32 @@ void srt_stream_write(srt_stream_data* sdata, const float* left, const float* ri
         sdata->stereo_buffer[2 * i] = left[i];
         sdata->stereo_buffer[2 * i + 1] = right[i];
     }
-    srt_stream_write(sdata, sdata->stereo_buffer, sample_count * 2 * sizeof(float));
+    if (sdata->format == SRT_STREAM_WAV) {
+        if (sample_count * 2 > sdata->pcm_buffer_len)
+            return;
+        for (size_t i = 0; i < sample_count * 2; ++i) {
+            float v = sdata->stereo_buffer[i];
+            if (v > 1.0f)
+                v = 1.0f;
+            else if (v < -1.0f)
+                v = -1.0f;
+            sdata->pcm_buffer[i] = (int16_t)(v * 32767.0f);
+        }
+        srt_stream_send(sdata, (const char*)sdata->pcm_buffer, sample_count * 2 * sizeof(int16_t));
+    } else {
+        srt_stream_send(sdata, (const char*)sdata->stereo_buffer, sample_count * 2 * sizeof(float));
+    }
 }
 
 void srt_stream_shutdown(srt_stream_data* sdata) {
-    for (auto s : sdata->clients) {
-        srt_close(s);
+    for (auto& c : sdata->clients) {
+        srt_close(c.sock);
     }
     sdata->clients.clear();
+    free(sdata->stereo_buffer);
+    sdata->stereo_buffer = NULL;
+    free(sdata->pcm_buffer);
+    sdata->pcm_buffer = NULL;
     if (sdata->listen_socket != SRT_INVALID_SOCK) {
         srt_close(sdata->listen_socket);
         sdata->listen_socket = SRT_INVALID_SOCK;


### PR DESCRIPTION
## Summary
- extend SRT streaming to support PCM, MP3 and new WAV formats
- send a WAV header to new clients when using `format = "wav"`
- suppress noisy libsrt messages
- update configuration example and documentation
- disable bit reservoir in MP3 encoder and disable SRT TSBPD mode to lower latency

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6860861b1084832596bc799fcef04cb3